### PR TITLE
Fixes the reds on the site. 

### DIFF
--- a/source/_patterns/00-atoms/00-global/00-brand-colors.mustache
+++ b/source/_patterns/00-atoms/00-global/00-brand-colors.mustache
@@ -1,9 +1,9 @@
 <ul class="sg-colors">
   <li>
-      <span class="sg-swatch" style="background: #E3321A;"></span>
+      <span class="sg-swatch" style="background: #E2231A;"></span>
       <span class="sg-label">
         $color-brand-red <br />
-        #E3321A
+        #E2231A
       </span>
   </li>
 </ul>

--- a/source/css/scss/abstracts/_variables.scss
+++ b/source/css/scss/abstracts/_variables.scss
@@ -21,7 +21,7 @@
 //    palettes easier to identify.
 // 2) Brand color variables should typically not be used directly in Sass
 //    partials. Instead, use second-tier application colors.
- $color-brand-red: #e3321a;
+ $color-brand-red: #e2231a;
 
 
 // Neutral Colors

--- a/source/css/scss/base/_forms.scss
+++ b/source/css/scss/base/_forms.scss
@@ -114,10 +114,10 @@ select {
  * Radio button styling.
  */
 
-$shadow: #000000;
-$outline: #ffffff;
-$selected: #e3321a;
-$unselected: #ffffff;
+$shadow: $color-gray-90;
+$outline:  $color-white;
+$selected: $color-brand-red;
+$unselected:  $color-white;
 
 input[type="radio"] {
   display: none;
@@ -153,7 +153,7 @@ input[type="radio"]:checked + label span{
     width: 30px;
     top: 0;
     left: 0;
-    border: 1px solid black;
+    border: 1px solid $color-gray-90;
     border-radius: 1px;
     background: white;
     cursor: pointer;
@@ -163,7 +163,7 @@ input[type="radio"]:checked + label span{
       height: 8px;
       top: 4px;
       left: 4px;
-      border: 6px solid #e3321a;
+      border: 6px solid $color-brand-red;
       border-top: none;
       border-right: none;
       background: transparent;

--- a/source/images/sp-logomark.svg
+++ b/source/images/sp-logomark.svg
@@ -5,7 +5,7 @@
     <desc>Created with Sketch.</desc>
     <defs></defs>
     <g id="Symbols" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="nav-header-1440" transform="translate(-164.000000, -28.000000)" fill="#E3321A">
+        <g id="nav-header-1440" transform="translate(-164.000000, -28.000000)" fill="#E2231A">
             <g id="nav-header-desktop-1440">
                 <g id="logo" transform="translate(163.000000, 28.000000)">
                     <g id="logomark">

--- a/source/images/sp-wordmark.svg
+++ b/source/images/sp-wordmark.svg
@@ -5,7 +5,7 @@
     <desc>Created with Sketch.</desc>
     <defs></defs>
     <g id="Symbols" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="nav-header-1440" transform="translate(-208.000000, -39.000000)" fill="#E3321A">
+        <g id="nav-header-1440" transform="translate(-208.000000, -39.000000)" fill="#E2231A">
             <g id="nav-header-desktop-1440">
                 <g id="logo" transform="translate(163.000000, 28.000000)">
                     <g id="wordmark" transform="translate(45.000000, 11.000000)">


### PR DESCRIPTION
I goofed. The site is using the wrong red. It …should be E2231A, not E3321A. I have failed you all as the keeper of color.

Please accept this PR as penance?

This fixes the global brand red color, the SVG logo assets, and I also corrected a couple of places where we should be using a variable for color, but had it hard-coded.