### PR TITLE
Added 5 blocks for the new site

### DIFF
--- a/source/css/scss/abstracts/_variables.scss
+++ b/source/css/scss/abstracts/_variables.scss
@@ -122,12 +122,15 @@ $space-and-half: $space*1.5;
 $space-double: $space*2;
 $space-triple: $space*3;
 $space-quad: $space*4;
+$space-quad-and-half: $space*4.5;
 $space-quint: $space*5;
 $space-half: $space/2;
 $pad: 8px;
 $pad-and-half: $pad*1.5;
 $pad-double: $pad*2;
+$pad-triple: $pad*3;
 $pad-quad: $pad*4;
+$pad-quad-and-half: $pad*4.5;
 $pad-half: $pad/2;
 $pad-quarter:$pad/4;
 

--- a/source/css/scss/components/_blocks.scss
+++ b/source/css/scss/components/_blocks.scss
@@ -235,3 +235,270 @@
   font-size: $font-size-med;
   font-weight: normal;
 }
+
+
+/*------------------------------------*\
+  #LARGE SPREAD BLOCK
+\*------------------------------------*/
+
+/**
+ * 1) The large spread block contains a title and various elements over an image with a gradient overlay.
+ */
+
+section.c-block-large-spread{
+  padding:54px $pad-quad-and-half;
+  max-width:$primary-column;
+  margin:0 auto;
+  background-size:cover;
+  background-position:center center;
+  position:relative;
+  &.large-spread-hero{
+    padding:$pad-quad-and-half;
+    min-height:550px;
+  }
+  &.content-right{
+    .c-block-large-spread__gradient{
+      background: linear-gradient(-135deg, rgba($color-gray-90,1) 0%,rgba($color-gray-90,0) 50%,rgba($color-gray-90,0) 100%);
+    }
+    .c-block-large-spread__content{
+      margin-left:auto;
+    }
+  }
+  &.margin-small{
+    margin-bottom:$space-triple;
+    @media(max-width:$bp-tablet){
+      margin-bottom:$space-double;
+    }
+  }
+  &.margin-medium{
+    margin-bottom:$space-quad-and-half;
+    @media(max-width:$bp-tablet){
+      margin-bottom:$space-triple;
+    }
+  }
+  &.margin-large{
+    margin-bottom:54px; // This is placeholder until we have variables.scss set.
+    @media(max-width:$bp-tablet){
+      margin-bottom:$space-quad-and-half;
+    }
+  }
+  &.margin-xl{
+    margin-bottom:81px; // This is placeholder until we have variables.scss set.
+    @media(max-width:$bp-tablet){
+      margin-bottom:54px;
+    }
+  }
+  &.margin-xxl{
+    margin-bottom:182px; // This is placeholder until we have variables.scss set.
+    @media(max-width:$bp-tablet){
+      margin-bottom:122px;
+    }
+  }
+  .c-block-large-spread__gradient{
+    background: linear-gradient(135deg, rgba($color-gray-90,1) 0%,rgba($color-gray-90,0) 50%,rgba($color-gray-90,0) 100%);
+    position:absolute;
+    width:100%;
+    height:100%;
+    left:0;
+    top:0;
+  }
+  .c-block-large-spread__content{
+    position:relative;
+    max-width:50%;
+    @media(max-width:$bp-tablet){
+      max-width:none;
+    }
+    .c-block-large-spread__title{
+      color:$color-white;
+      margin-bottom:$space-triple;
+    }
+    h1.c-block-large-spread__title{
+      font-size: 54px;
+      line-height: 60px;
+      @media(max-width:$bp-tablet){
+        font-size: 50px;
+        line-height: 56px;
+      }
+      @media(max-width:$bp-mobile){
+        font-size: 36px;
+        line-height: 40px;
+      }
+    }
+    .c-block-large-spread__copy{
+      color:$color-white;
+      font-size: 16px;
+      letter-spacing: 0;
+      line-height: 24px;
+      *{
+        color:$color-white;
+      }
+    }
+    .sp-btn{
+
+    }
+  }
+}
+
+
+ /*------------------------------------*\
+  #MEDIUM SPREAD BLOCK
+\*------------------------------------*/
+
+/**
+ * 1) The medium spread block contains a title and text over an image with a gradient overlay.
+ */
+
+ div.c-block-medium-spread{
+    padding:$pad-triple;
+    width:500px;
+    height:500px;
+    background-size:cover;
+    background-position:center center;
+    position:relative;
+    @media(max-width:$bp-tablet){
+      width:100%;
+    }
+    .c-block-medium-spread__gradient{
+      background: linear-gradient(135deg, rgba($color-gray-90,1) 0%,rgba($color-gray-90,0) 50%,rgba($color-gray-90,0) 100%);
+      position:absolute;
+      width:100%;
+      height:100%;
+      left:0;
+      top:0;
+    }
+    .c-block-medium-spread__content{
+      position:relative;
+      max-width:50%;
+      @media(max-width:$bp-tablet){
+        max-width:none;
+      }
+      .c-block-medium-spread__title{
+        color:$color-white;
+        margin-bottom:$space-and-half;
+      }
+      .c-block-medium-spread__copy{
+        color:$color-white;
+        font-size: 16px;
+        letter-spacing: 0;
+        line-height: 24px;
+        *{
+          color:$color-white;
+        }
+      }
+    }
+ }
+
+
+ /*------------------------------------*\
+  #SIDE BY SIDE BLOCK
+\*------------------------------------*/
+
+/**
+ * 1) The side by side block contains a title and text in a container with a background color on one side and a box with a background image on the other.
+ */
+
+ div.c-block-side-by-side{
+    width:500px;
+    height:238px;
+    position:relative;
+    display:flex;
+    @media(max-width:$bp-tablet){
+      width:100%;
+    }
+    &.content-right{
+      .c-block-side-by-side__content{
+        order:2;
+      }
+    }
+    .c-block-side-by-side__content{
+      width:50%;
+      padding:$pad-triple;
+      background-color:$color-gray-02;
+      height:100%;
+      @media(max-width:$bp-tablet){
+        width:100%;
+      }
+      .c-block-side-by-side__title{
+        margin-bottom:$space-and-half;
+      }
+      .c-block-side-by-side__copy{
+        font-size: 16px;
+        letter-spacing: 0;
+        line-height: 24px;
+      }
+    }
+    .c-block-side-by-side__image{
+      width:50%;
+      height:100%;
+      background-size:cover;
+      background-position:center center;
+      @media(max-width:$bp-tablet){
+        width:0%;
+      }
+    }
+ }
+
+
+ /*------------------------------------*\
+  #OVER UNDER BLOCK
+\*------------------------------------*/
+
+/**
+ * 1) The over under block contains a title and text in a container with a background color below a box with a background image.
+ */
+
+ .c-block-over-under{
+      height:500px;
+      width:500px;
+      @media(max-width:$bp-tablet){
+        width:100%;
+      }
+    .c-block-over-under__image{
+      height:262px;
+      width:100%;
+      background-size:cover;
+      background-position:center center;
+    }
+    .c-block-over-under__content{
+      width:100%;
+      padding:$pad-triple;
+      background-color:$color-gray-02;
+      height:238px;
+      .c-block-over-under__title{
+        margin-bottom:$space-and-half;
+      }
+      .c-block-over-under__copy{
+        font-size: 16px;
+        letter-spacing: 0;
+        line-height: 24px;
+      }
+    }
+ }
+
+  /*------------------------------------*\
+  #RESOURCE BLOCK
+\*------------------------------------*/
+
+/**
+ * 1) The resource block contains a title and link inside a container with a background color.
+ */
+
+ div.c-block-resource{
+  position:relative;
+    width:238px;
+    height:238px;
+    padding:$pad-triple;
+    background-color:$color-gray-02;
+    .c-block-resource__content{
+      .c-block-resource__title{
+
+      }
+    }
+    .c-block-resource__link{
+      position:absolute;
+      bottom:$space-triple;
+      a{
+        font-family: "Graphik Semibold";
+      }
+    }
+ }

--- a/source/css/scss/components/_buttons.scss
+++ b/source/css/scss/components/_buttons.scss
@@ -5,7 +5,7 @@
 /**
  * Button
  */
-.sp-btn {
+.sp-btn,a.cta_button {
 
   display: inline-block;
   box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12), 0 3px 1px -2px rgba(0, 0, 0, 0.2);


### PR DESCRIPTION
This PR includes styles for 5 new blocks for the new website.

-Large Spread Block
-Medium Spread Block
-Side by Side Block
-Over Under Block
-Resource Block

The PR also adds the HubSpot CTA class to the general button styles and adds a couple new space and pad variables.

[I created a demo page of the blocks here:](http://superpedestrian-4012688.hs-sites.com/-temporary-slug-846319e7-bb2f-4fe7-b0c0-f320fc2c0cdd?hs_preview=zonMXorC-5676237800)

[This is the HubSpot template file for the new blocks:](https://app.hubspot.com/design-manager/4012688/templates/5676049753)